### PR TITLE
Fix code scanning alert no. 21: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -74,7 +74,7 @@ jobs:
           name: app-jar
           
       - name: Download app.yaml artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@4.1.7
         with:
           name: app-yaml
         


### PR DESCRIPTION
Fixes [https://github.com/nabarun-ngo/ngo-nabarun-be/security/code-scanning/21](https://github.com/nabarun-ngo/ngo-nabarun-be/security/code-scanning/21)

To fix the problem, we need to update the `actions/download-artifact` action from version `v3` to `4.1.7`, which is not vulnerable. This change should be made in the `.github/workflows/stage.yml` file. The update will ensure that the workflow uses a secure version of the action without altering its existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
